### PR TITLE
Support Typing Extensions 4.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 license = {file = "LICENSE"}
 dependencies = [
-    "typing-extensions >=3.7.4, <4.0.0"
+    "typing-extensions >=4.0.0, <5.0.0"
 ]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
This PR changes to support Typing Extensions 4.x.

[Typing Extensions 4.0.0](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-400-november-14-2021) has removed some types, but it has no effect on Agraffe.

Thank you.